### PR TITLE
Corrected VariantInit() and Win32VariantBool:

### DIFF
--- a/PharoCOM/Ole32Lib.class.st
+++ b/PharoCOM/Ole32Lib.class.st
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #'ffi-calls' }
-Ole32Lib >> ffiCoCreateInstance:pointer of:clsid as: riid. [
+Ole32Lib >> ffiCoCreateInstance:pointer of:clsid as: riid [.
 	self ffiCall: #(HRESULT CoCreateInstance(GUID* clsid , 0, 16r15, GUID* riid, void* pointer))
 ]
 

--- a/PharoCOM/OleAut32Lib.class.st
+++ b/PharoCOM/OleAut32Lib.class.st
@@ -31,7 +31,7 @@ OleAut32Lib >> ffiVariantClear: aPointer [
 
 { #category : #'as yet unclassified' }
 OleAut32Lib >> ffiVariantInit: pointer [
-	^ self ffiCall: #(HRESULT VariantInit #(void * pointer))
+	^ self ffiCall: #(void VariantInit #(void * pointer))
 ]
 
 { #category : #'accessing platform' }

--- a/PharoCOM/Win32Variant.class.st
+++ b/PharoCOM/Win32Variant.class.st
@@ -127,10 +127,6 @@ Win32Variant >> getHandleAsExternalAddress [
 Win32Variant >> init [
 	" Inits the variant to be used in COM calls"
 	OleAut32Lib uniqueInstance ffiVariantInit: self getHandleAsExternalAddress.
-	
-"	| returnCode | "
-"	returnCode := OleAut32Lib uniqueInstance ffiVariantInit: self getHandleAsExternalAddress.  "
-"	self reportErrorIfNoZero: returnCode.  "
 ]
 
 { #category : #printing }

--- a/PharoCOM/Win32Variant.class.st
+++ b/PharoCOM/Win32Variant.class.st
@@ -126,9 +126,11 @@ Win32Variant >> getHandleAsExternalAddress [
 { #category : #initialization }
 Win32Variant >> init [
 	" Inits the variant to be used in COM calls"
-	| returnCode |
-	returnCode := OleAut32Lib uniqueInstance ffiVariantInit: self getHandleAsExternalAddress.
-	self reportErrorIfNoZero: returnCode.
+	OleAut32Lib uniqueInstance ffiVariantInit: self getHandleAsExternalAddress.
+	
+"	| returnCode | "
+"	returnCode := OleAut32Lib uniqueInstance ffiVariantInit: self getHandleAsExternalAddress.  "
+"	self reportErrorIfNoZero: returnCode.  "
 ]
 
 { #category : #printing }

--- a/PharoCOM/Win32VariantBool.class.st
+++ b/PharoCOM/Win32VariantBool.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #Win32VariantBool,
 	#superclass : #Win32VariantType,
-	#category : 'PharoCOM-Variant-Types'
+	#category : #'PharoCOM-Variant-Types'
 }
 
 { #category : #accessing }
@@ -11,11 +11,14 @@ Win32VariantBool >> readFrom: aVariant [
 
 { #category : #accessing }
 Win32VariantBool >> write: aValue to: aVariant [
+	| localData |
+	localData := aVariant data .
 	aValue
 		ifTrue: [ 
-			aVariant data at: 1 put: 16rFF.
-			aVariant data at: 2 put: 16rFF ]
+			localData at: 1 put: 16rFF.
+			localData at: 2 put: 16rFF ]
 		ifFalse: [ 
-			aVariant data at: 1 put: 0.
-			aVariant data at: 2 put: 0 ]
+			localData at: 1 put: 0.
+			localData at: 2 put: 0 ].
+	aVariant data: localData
 ]


### PR DESCRIPTION
Changes:
- VariantInit() doesn't return HRESULT (as per https://docs.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-variantinit) so the ffi call to VariantInit() in `OleAut32Lib>>#ffiVariantInit:` changed accordingly
- according to the above updated `Win32Variant>>#init`  
- writing with `aWin32Variant data at: .. put: ..` is "by value" so the data isn't actually changed; corrected with the local copy of aWin32Variant data in `Win32VariantBool>>#write:to:`

testAccessingBoolProperties is now green.

Tomaz