### PR TITLE
Property getters with parameters, calling methods with arguments of type Variant *

### DIFF
--- a/PharoCOM-Tests/IDispatchTest.class.st
+++ b/PharoCOM-Tests/IDispatchTest.class.st
@@ -108,20 +108,21 @@ IDispatchTest >> testCallingVoidFunction [
 
 { #category : #tests }
 IDispatchTest >> testWord [
-	| wrd documents sel someText |
+	| wrd documents selection someText |
 	self isCI ifTrue: [ ^self skip ]. "CI detect"
 
 	someText := 'Hello from Pharo!'.
 	
 	Ole32Lib uniqueInstance initLibrary.
+	
 	wrd := COMDispatchInstance createInstanceByName: 'Word.Application'.
 	wrd propertyNamed: 'Visible' put: true. 
 	documents := wrd propertyNamed: 'Documents'.
 	documents dispatch: 'Add'.
-	sel := wrd propertyNamed: 'Selection'. 
-	sel dispatch: 'TypeText' withArguments: { someText }.
-	sel dispatch: 'WholeStory' .
-	self assert: (sel propertyNamed: 'Text') allButLast equals: someText.
+	selection := wrd propertyNamed: 'Selection'. 
+	selection dispatch: 'TypeText' withArguments: { someText }.
+	selection dispatch: 'WholeStory' .
+	self assert: (selection propertyNamed: 'Text') allButLast equals: someText.
 	
 	documents dispatch: 'Add'.
 	(wrd propertyNamed: 'Selection') 
@@ -129,8 +130,8 @@ IDispatchTest >> testWord [
 		withArguments: { (someText, ' Some additional text.') }.
 	(documents dispatch: 'Item' withArguments: { 2 })
 		dispatch: 'Activate'.
-	sel := wrd propertyNamed: 'Selection'. 
-	sel dispatch: 'WholeStory' .
-	self assert: (sel propertyNamed: 'Text') allButLast equals: someText.
+	selection := wrd propertyNamed: 'Selection'. 
+	selection dispatch: 'WholeStory' .
+	self assert: (selection propertyNamed: 'Text') allButLast equals: someText.
 	
 ]

--- a/PharoCOM-Tests/IDispatchTest.class.st
+++ b/PharoCOM-Tests/IDispatchTest.class.st
@@ -42,7 +42,7 @@ IDispatchTest >> testADODBConnectionAndRecordset [
 
 { #category : #tests }
 IDispatchTest >> testADODBRecordset [
-	| rst recordCount |
+	| rst recordCountLoop recordCountReported |
 	self isCI ifTrue: [ ^self skip ]. "CI detect"
 
 	Ole32Lib uniqueInstance initLibrary.
@@ -50,11 +50,17 @@ IDispatchTest >> testADODBRecordset [
 	rst dispatch: 'Open' withArguments: { 
 		'Table name or SQL SELECT' . 
 		'connection string including authentication details (usrn pwd)' . 
-		3 . 
-		1 } . 
-	recordCount := rst propertyNamed: 'RecordCount'.  
+		3 .   "<-- CursorType adOpenStatic"
+		1 } . "<-- LockType adLockReadOnly"
+	recordCountLoop := 0.
+	[ rst propertyNamed: 'EOF' ] whileFalse: [ 
+		recordCountLoop := recordCountLoop + 1.
+		rst dispatch: 'MoveNext'
+	 ].
+	recordCountReported := rst propertyNamed: 'RecordCount'.  
 	rst dispatch: 'Close'.
-	self assert: recordCount  equals: 14566   "<-- change to number of records"
+	self assert: recordCountLoop  equals: recordCountReported
+
 
 ]
 

--- a/PharoCOM-Tests/IDispatchTest.class.st
+++ b/PharoCOM-Tests/IDispatchTest.class.st
@@ -108,18 +108,29 @@ IDispatchTest >> testCallingVoidFunction [
 
 { #category : #tests }
 IDispatchTest >> testWord [
-	| wrd docs sel someText |
+	| wrd documents sel someText |
 	self isCI ifTrue: [ ^self skip ]. "CI detect"
 
 	someText := 'Hello from Pharo!'.
+	
 	Ole32Lib uniqueInstance initLibrary.
 	wrd := COMDispatchInstance createInstanceByName: 'Word.Application'.
 	wrd propertyNamed: 'Visible' put: true. 
-	docs := wrd propertyNamed: 'Documents'.
-	docs dispatch: 'Add'.
+	documents := wrd propertyNamed: 'Documents'.
+	documents dispatch: 'Add'.
 	sel := wrd propertyNamed: 'Selection'. 
 	sel dispatch: 'TypeText' withArguments: { someText }.
 	sel dispatch: 'WholeStory' .
 	self assert: (sel propertyNamed: 'Text') allButLast equals: someText.
-
+	
+	documents dispatch: 'Add'.
+	(wrd propertyNamed: 'Selection') 
+		dispatch: 'TypeText' 
+		withArguments: { (someText, ' Some additional text.') }.
+	(documents dispatch: 'Item' withArguments: { 2 })
+		dispatch: 'Activate'.
+	sel := wrd propertyNamed: 'Selection'. 
+	sel dispatch: 'WholeStory' .
+	self assert: (sel propertyNamed: 'Text') allButLast equals: someText.
+	
 ]

--- a/PharoCOM-Tests/VariantsTests.class.st
+++ b/PharoCOM-Tests/VariantsTests.class.st
@@ -4,23 +4,46 @@ Class {
 	#category : #'PharoCOM-Tests'
 }
 
+{ #category : #testing }
+VariantsTests >> isCI [
+	^ (OSEnvironment current at: 'CI' ifAbsent: [ 'false' ]) asLowercase = 'true' 
+]
+
 { #category : #tests }
 VariantsTests >> testDate [ 
 	| variant type valuePut valueGet  |
+	self isCI ifTrue: [ ^self skip ]. "CI detect"
+
+	valuePut := Date today.
+
+	variant := Win32Variant externalNew .
+	variant autoRelease .
+	variant init.
+
+	valuePut asWin32VariantInto: variant.
+
+	type := Win32Variant typeFor: 7. "<-- date"
+	
+	valueGet := type readFrom: variant.
+	self assert: valueGet asDate equals: valuePut asDate.
+]
+
+{ #category : #tests }
+VariantsTests >> testDateAndTime [ 
+	| variant type valuePut valueGet  |
+	self isCI ifTrue: [ ^self skip ]. "CI detect"	
+	
 	valuePut := DateAndTime now truncated.
 	
 	variant := Win32Variant externalNew .
 	variant autoRelease .
 	variant init.
 
+	valuePut asWin32VariantInto: variant.
+
 	type := Win32Variant typeFor: 7. "<-- date"
-	variant vt: type typeNumber .
-	type write: valuePut to: variant.
 	
-	valueGet := (type readFrom: variant) offset: (Duration hours: 2).
-	self assert: valueGet equals: valuePut.
-	
-	valueGet := (type readFrom: variant).
+	valueGet := type readFrom: variant.
 	self assert: valueGet equals: valuePut.
 ]
 

--- a/PharoCOM-Tests/VariantsTests.class.st
+++ b/PharoCOM-Tests/VariantsTests.class.st
@@ -7,16 +7,70 @@ Class {
 { #category : #tests }
 VariantsTests >> testDate [ 
 	| variant type valuePut valueGet  |
-	valuePut := DateAndTime now.
+	valuePut := DateAndTime now truncated.
 	
 	variant := Win32Variant externalNew .
 	variant autoRelease .
 	variant init.
 
-	type := Win32Variant typeFor: 7. "<-- boolean"
+	type := Win32Variant typeFor: 7. "<-- date"
+	variant vt: type typeNumber .
+	type write: valuePut to: variant.
+	
+	valueGet := (type readFrom: variant) offset: (Duration hours: 2).
+	self assert: valueGet equals: valuePut.
+	
+	valueGet := (type readFrom: variant).
+	self assert: valueGet equals: valuePut.
+]
+
+{ #category : #tests }
+VariantsTests >> testDecimal [
+	| variant type valuePut valueGet  |
+	valuePut := 12345.54321 asScaledDecimal: 4.
+	
+	variant := Win32Variant externalNew .
+	variant autoRelease .
+	variant init.
+
+	type := Win32Variant typeFor: 14. "<-- decimal"
+	variant vt: type typeNumber .
+	type write: valuePut to: variant.
+	
+	valueGet := type readFrom: variant.
+	self assert: (valuePut round: 4) equals: (valueGet round: 4)
+]
+
+{ #category : #tests }
+VariantsTests >> testDouble [
+	| variant type valuePut valueGet  |
+	valuePut := 12345.54321. 
+	
+	variant := Win32Variant externalNew .
+	variant autoRelease .
+	variant init.
+
+	type := Win32Variant typeFor: 5. "<-- double"
 	variant vt: type typeNumber .
 	type write: valuePut to: variant.
 	
 	valueGet := type readFrom: variant.
 	self assert: valuePut equals: valueGet
+]
+
+{ #category : #tests }
+VariantsTests >> testNull [
+	| variant type valuePut valueGet  |
+	valuePut := 'anything'.
+
+	variant := Win32Variant externalNew .
+	variant autoRelease .
+	variant init.
+
+	type := Win32Variant typeFor: 1. "<-- null"
+	variant vt: type typeNumber .
+	type write: valuePut to: variant.
+	
+	valueGet := type readFrom: variant.
+	self assert: valueGet equals: nil
 ]

--- a/PharoCOM-Tests/VariantsTests.class.st
+++ b/PharoCOM-Tests/VariantsTests.class.st
@@ -1,0 +1,22 @@
+Class {
+	#name : #VariantsTests,
+	#superclass : #TestCase,
+	#category : #'PharoCOM-Tests'
+}
+
+{ #category : #tests }
+VariantsTests >> testDate [ 
+	| variant type valuePut valueGet  |
+	valuePut := DateAndTime now.
+	
+	variant := Win32Variant externalNew .
+	variant autoRelease .
+	variant init.
+
+	type := Win32Variant typeFor: 7. "<-- boolean"
+	variant vt: type typeNumber .
+	type write: valuePut to: variant.
+	
+	valueGet := type readFrom: variant.
+	self assert: valuePut equals: valueGet
+]

--- a/PharoCOM/COMDispatchInstance.class.st
+++ b/PharoCOM/COMDispatchInstance.class.st
@@ -8,7 +8,7 @@ Class {
 	#pools : [
 		'COMTypes'
 	],
-	#category : 'PharoCOM'
+	#category : #PharoCOM
 }
 
 { #category : #'instance creation' }
@@ -138,6 +138,13 @@ COMDispatchInstance >> propertyNamed: aPropName put: aValue [
 	| prop |
 	prop := self getDispatchType properties detect: [ :e | e name = aPropName ].
 	^ prop write: aValue to: self.
+]
+
+{ #category : #'as yet unclassified' }
+COMDispatchInstance >> propertyNamed: aPropName withArguments: arguments [
+	| prop |
+	prop := self getDispatchType properties detect: [ :e | e name = aPropName ].
+	^ prop getFrom: self withArguments: arguments.
 ]
 
 { #category : #querying }

--- a/PharoCOM/COMProperty.class.st
+++ b/PharoCOM/COMProperty.class.st
@@ -10,7 +10,7 @@ Class {
 	#pools : [
 		'COMTypes'
 	],
-	#category : 'PharoCOM'
+	#category : #PharoCOM
 }
 
 { #category : #'instance creation' }
@@ -31,6 +31,12 @@ COMProperty >> calculateType [
 COMProperty >> getFrom: aObj [ 
 	getter ifNil: [ self error: 'The property ' , name , ' does not allow to be read.'  ].
 	^ getter invokeOn: aObj withArgs: #().
+]
+
+{ #category : #accessing }
+COMProperty >> getFrom: aObj withArguments: arguments [ 
+	getter ifNil: [ self error: 'The property ' , name , ' does not allow to be read.'  ].
+	^ getter invokeOn: aObj withArgs: arguments.
 ]
 
 { #category : #accessing }

--- a/PharoCOM/Date.extension.st
+++ b/PharoCOM/Date.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #Date }
+
+{ #category : #'*PharoCOM' }
+Date >> asWin32VariantInto: aVariant [
+	| type | 
+	type := Win32Variant typeFor: 7. "<-- can this be done with #DATE and TypeMapping?"
+	type write: self to: aVariant
+]

--- a/PharoCOM/DateAndTime.extension.st
+++ b/PharoCOM/DateAndTime.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #DateAndTime }
 
 { #category : #'*PharoCOM' }
+DateAndTime >> asWin32VariantInto: aVariant [
+	| type | 
+	type := Win32Variant typeFor: 7. "<-- can this be done with #DATE and TypeMapping?"
+	type write: self to: aVariant
+]
+
+{ #category : #'*PharoCOM' }
 DateAndTime class >> oleEpoch [
 	"Answer a DateAndTime representing the DOS epoch (days since midnight 30 December 1899)"
 

--- a/PharoCOM/DateAndTime.extension.st
+++ b/PharoCOM/DateAndTime.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #DateAndTime }
+
+{ #category : #'*PharoCOM' }
+DateAndTime class >> oleEpoch [
+	"Answer a DateAndTime representing the DOS epoch (30 December 1900 at midnight to 31 December)"
+
+	^ self basicNew
+		ticks: #(2415021 0 0) offset: Duration zero;
+		yourself.
+]

--- a/PharoCOM/DateAndTime.extension.st
+++ b/PharoCOM/DateAndTime.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #DateAndTime }
 
 { #category : #'*PharoCOM' }
 DateAndTime class >> oleEpoch [
-	"Answer a DateAndTime representing the DOS epoch (30 December 1900 at midnight to 31 December)"
+	"Answer a DateAndTime representing the DOS epoch (days since midnight 30 December 1899)"
 
 	^ self basicNew
 		ticks: #(2415021 0 0) offset: Duration zero;

--- a/PharoCOM/Win32Variant.class.st
+++ b/PharoCOM/Win32Variant.class.st
@@ -44,20 +44,20 @@ Win32Variant class >> initializeTypeMapping [
 	PointerType := 26.
 
 	TypeMapping := ({
-		(Win32VariantUnimplementedType new: #NULL as: 1).
+		(Win32VariantNull new: #NULL as: 1).
 		(Win32VariantUnimplementedType new: #int16 as: 2).
 		(Win32VariantInt32 new: #int32 as: 3).
 		(Win32VariantUnimplementedType new: #float as: 4).
-		(Win32VariantUnimplementedType new: #double as: 5).
+		(Win32VariantDouble new: #double as: 5).
 		(Win32VariantUnimplementedType new: #CURRENCY as: 6).
-		(Win32VariantUnimplementedType new: #DATE as: 7).
+		(Win32VariantDate new: #DATE as: 7).
 		(Win32VariantBSTRString new: #BSTRString as: 8).
 		(Win32VariantCOMInstance new: #COMDispatchInstance as: 9).
 		(Win32VariantUnimplementedType new: #ERROR as: 10).
 		(Win32VariantBool new: #BOOL as: 11).
 		(Win32VariantType new: #Win32Variant as: 12).
 		(Win32VariantCOMInstance new: #COMUnknownInstance as: 13).
-		(Win32VariantUnimplementedType new: #DECIMAL as: 14).
+		(Win32VariantDecimal new: #DECIMAL as: 14).
 		(Win32VariantUnimplementedType new: #byte as: 16).
 		(Win32VariantUnimplementedType new: #ubyte as: 17).
 		(Win32VariantUnimplementedType new: #uint16 as: 18).

--- a/PharoCOM/Win32Variant.class.st
+++ b/PharoCOM/Win32Variant.class.st
@@ -71,7 +71,7 @@ Win32Variant class >> initializeTypeMapping [
 		(Win32VariantUnimplementedType new: #PTR as: 26).
 		(Win32VariantUnimplementedType new: #SAFEARRAY as: 27).
 		(Win32VariantUnimplementedType new: #CARRAY as: 28).
-		(Win32VariantUserDefinedType new: #USERDEFINED as: 29).
+		(Win32VariantUserDefined new: #USERDEFINED as: 29).
 		(Win32VariantUnimplementedType new: #String as: 30).
 		(Win32VariantUnimplementedType new: #Win32WideString as: 31).
 		(Win32VariantUnimplementedType new: #RECORD as: 32).

--- a/PharoCOM/Win32VariantDate.class.st
+++ b/PharoCOM/Win32VariantDate.class.st
@@ -4,15 +4,17 @@ Class {
 	#category : #'PharoCOM-Variant-Types'
 }
 
+{ #category : #'as yet unclassified' }
+Win32VariantDate >> checkIfElementaryTypeAndWrite: aValue to: aVariant [
+	self write: aValue to: aVariant
+]
+
 { #category : #accessing }
 Win32VariantDate >> readFrom: aVariant [
 	| dateAsFloat |
 	dateAsFloat := (aVariant rawData copyFrom: 1 to: 8) doubleAt: 1 bigEndian: false.
 	dateAsFloat := dateAsFloat + DateAndTime oleEpoch julianDayNumber - 2.
-	^ DateAndTime julianDayNumber: dateAsFloat.
-
-	
-
+	^ (DateAndTime julianDayNumber: dateAsFloat) truncated.
 ]
 
 { #category : #accessing }

--- a/PharoCOM/Win32VariantDate.class.st
+++ b/PharoCOM/Win32VariantDate.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #Win32VariantDate,
+	#superclass : #Win32VariantType,
+	#category : #'PharoCOM-Variant-Types'
+}
+
+{ #category : #accessing }
+Win32VariantDate >> readFrom: aVariant [
+	| dateAsFloat |
+	dateAsFloat := (aVariant rawData copyFrom: 1 to: 8) doubleAt: 1 bigEndian: false.
+	dateAsFloat := dateAsFloat + DateAndTime oleEpoch julianDayNumber - 2.
+	^ DateAndTime julianDayNumber: dateAsFloat.
+
+	
+
+]
+
+{ #category : #accessing }
+Win32VariantDate >> write: aValue to: aVariant [
+	| dateAsFloat seconds |
+	aVariant vt: self typeNumber.
+
+	dateAsFloat := aValue julianDayNumber - DateAndTime oleEpoch julianDayNumber + 2.
+	seconds := aValue secondsSinceMidnightUTC .
+	dateAsFloat := dateAsFloat + (seconds / 86400.0)	.
+	
+	aVariant rawData doubleAt: 1 put: dateAsFloat.
+]

--- a/PharoCOM/Win32VariantDate.class.st
+++ b/PharoCOM/Win32VariantDate.class.st
@@ -23,8 +23,9 @@ Win32VariantDate >> write: aValue to: aVariant [
 	aVariant vt: self typeNumber.
 
 	dateAsFloat := aValue julianDayNumber - DateAndTime oleEpoch julianDayNumber + 2.
-	seconds := aValue secondsSinceMidnightUTC .
-	dateAsFloat := dateAsFloat + (seconds / 86400.0)	.
+	(aValue class = DateAndTime) ifTrue: [ 
+		seconds := aValue secondsSinceMidnightUTC .
+		dateAsFloat := dateAsFloat + (seconds / 86400.0)]	.
 	
 	aVariant rawData doubleAt: 1 put: dateAsFloat.
 ]

--- a/PharoCOM/Win32VariantDecimal.class.st
+++ b/PharoCOM/Win32VariantDecimal.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'PharoCOM-Variant-Types'
 }
 
+{ #category : #'as yet unclassified' }
+Win32VariantDecimal >> checkIfElementaryTypeAndWrite: aValue to: aVariant [
+	self write: aValue to: aVariant
+]
+
 { #category : #accessing }
 Win32VariantDecimal >> readFrom: aVariant [
 	| hi mid lo sign scale value |
@@ -13,16 +18,34 @@ Win32VariantDecimal >> readFrom: aVariant [
 	sign := aVariant rawData unsignedByteAt: -4.
 	scale := aVariant rawData unsignedByteAt: -5.
 	
-	value := hi asScaledDecimal * 16r100000000.
-	value := value + (mid asScaledDecimal * 16r10000).
-	value := value + lo.
-	(sign = 0) ifFalse: [value := value * -1].
-	value setNumerator: value numerator denominator: (10 raisedTo: scale) scale: scale.
+	value := ((hi bitShift: 64) bitOr: (mid bitShift: 32)) bitOr: lo.
+	(sign = 0) ifFalse: [value := value negated].
+	
+	^ ScaledDecimal new setNumerator: value denominator: (10 raisedTo: scale) scale: scale.
 
-	^ value 
 ]
 
 { #category : #accessing }
 Win32VariantDecimal >> write: aValue to: aVariant [
-	nil 
+	| hi mid lo sign scale value |
+	aVariant vt: self typeNumber.
+
+	scale := 2.
+	(aValue class = ScaledDecimal) 
+		ifTrue: [ scale := aValue scale ].
+	sign := 0. 
+	value := (aValue * (10 raisedToInteger: scale)) rounded. 
+	value < 0 ifTrue: [sign := 1. value := value negated]. 
+
+	hi := value bitShift: -64.
+	mid := (value bitShift: -32) bitAnd: 16rFFFFFFFF.
+	lo := value bitAnd: 16rFFFFFFFF.
+
+	aVariant rawData platformUnsignedLongAt: -3 put: hi.
+	aVariant rawData platformUnsignedLongAt: 5 put: mid.
+	aVariant rawData platformUnsignedLongAt: 1 put: lo.
+
+	aVariant rawData unsignedByteAt: -4 put: sign.
+	aVariant rawData unsignedByteAt: -5 put: scale.
+	
 ]

--- a/PharoCOM/Win32VariantDecimal.class.st
+++ b/PharoCOM/Win32VariantDecimal.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #Win32VariantDecimal,
+	#superclass : #Win32VariantType,
+	#category : #'PharoCOM-Variant-Types'
+}
+
+{ #category : #accessing }
+Win32VariantDecimal >> readFrom: aVariant [
+	| hi mid lo sign scale value |
+	hi := aVariant rawData platformUnsignedLongAt: -3.
+	mid := aVariant rawData platformUnsignedLongAt: 5.
+	lo := aVariant rawData platformUnsignedLongAt: 1.
+	sign := aVariant rawData unsignedByteAt: -4.
+	scale := aVariant rawData unsignedByteAt: -5.
+	
+	value := hi asScaledDecimal * 16r100000000.
+	value := value + (mid asScaledDecimal * 16r10000).
+	value := value + lo.
+	(sign = 0) ifFalse: [value := value * -1].
+	value setNumerator: value numerator denominator: (10 raisedTo: scale) scale: scale.
+
+	^ value 
+]
+
+{ #category : #accessing }
+Win32VariantDecimal >> write: aValue to: aVariant [
+	nil 
+]

--- a/PharoCOM/Win32VariantDouble.class.st
+++ b/PharoCOM/Win32VariantDouble.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'PharoCOM-Variant-Types'
 }
 
+{ #category : #'as yet unclassified' }
+Win32VariantDouble >> checkIfElementaryTypeAndWrite: aValue to: aVariant [
+	self write: aValue to: aVariant
+]
+
 { #category : #accessing }
 Win32VariantDouble >> readFrom: aVariant [
 	^ (aVariant rawData copyFrom: 1 to: 8) doubleAt: 1 bigEndian: false.

--- a/PharoCOM/Win32VariantDouble.class.st
+++ b/PharoCOM/Win32VariantDouble.class.st
@@ -1,0 +1,16 @@
+Class {
+	#name : #Win32VariantDouble,
+	#superclass : #Win32VariantType,
+	#category : #'PharoCOM-Variant-Types'
+}
+
+{ #category : #accessing }
+Win32VariantDouble >> readFrom: aVariant [
+	^ (aVariant rawData copyFrom: 1 to: 8) doubleAt: 1 bigEndian: false.
+]
+
+{ #category : #accessing }
+Win32VariantDouble >> write: aValue to: aVariant [
+	aVariant vt: self typeNumber.
+	aVariant rawData doubleAt: 1 put: aValue.
+]

--- a/PharoCOM/Win32VariantNull.class.st
+++ b/PharoCOM/Win32VariantNull.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #Win32VariantNull,
+	#superclass : #Win32VariantType,
+	#category : #'PharoCOM-Variant-Types'
+}
+
+{ #category : #accessing }
+Win32VariantNull >> readFrom: aVariant [
+	^ nil 
+]
+
+{ #category : #accessing }
+Win32VariantNull >> write: aValue to: aVariant [
+	aVariant vt: self typeNumber. 
+]

--- a/PharoCOM/Win32VariantNull.class.st
+++ b/PharoCOM/Win32VariantNull.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'PharoCOM-Variant-Types'
 }
 
+{ #category : #'as yet unclassified' }
+Win32VariantNull >> checkIfElementaryTypeAndWrite: aValue to: aVariant [
+	self write: aValue to: aVariant
+]
+
 { #category : #accessing }
 Win32VariantNull >> readFrom: aVariant [
 	^ nil 

--- a/PharoCOM/Win32VariantPointer.class.st
+++ b/PharoCOM/Win32VariantPointer.class.st
@@ -21,7 +21,14 @@ Win32VariantPointer >> = other [
 
 { #category : #accessing }
 Win32VariantPointer >> checkIfElementaryTypeAndWrite: aValue to: aVariant [ 
-	aValue asWin32VariantInto: aVariant
+	| innerVariant |
+	innerVariant := Win32Variant externalNew.
+	innerVariant autoRelease.
+	innerVariant init.
+	aValue asWin32VariantInto: innerVariant.
+	
+	self write: innerVariant to: aVariant.
+
 ]
 
 { #category : #accessing }
@@ -42,4 +49,13 @@ Win32VariantPointer >> isVoid [
 { #category : #accessing }
 Win32VariantPointer >> typeName [
 	^ inner typeName , '*'
+]
+
+{ #category : #writing }
+Win32VariantPointer >> write: anInnerVariant to: aVariant [
+	| type |
+
+	type := Win32Variant typeFor: 12.
+	aVariant vt: type typeNumber + 16r4000.
+	aVariant rawData pointerAt: 1 put: anInnerVariant getHandleAsExternalAddress  .
 ]

--- a/PharoCOM/Win32VariantPointer.class.st
+++ b/PharoCOM/Win32VariantPointer.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'inner'
 	],
-	#category : 'PharoCOM-Variant-Types'
+	#category : #'PharoCOM-Variant-Types'
 }
 
 { #category : #'instance creation' }
@@ -17,6 +17,11 @@ Win32VariantPointer class >> wrap: otherType [
 { #category : #comparing }
 Win32VariantPointer >> = other [
 	^ other species = self species and: [ self inner = other inner ]
+]
+
+{ #category : #accessing }
+Win32VariantPointer >> checkIfElementaryTypeAndWrite: aValue to: aVariant [ 
+	aValue asWin32VariantInto: aVariant
 ]
 
 { #category : #accessing }

--- a/PharoCOM/Win32VariantPointer.class.st
+++ b/PharoCOM/Win32VariantPointer.class.st
@@ -56,6 +56,6 @@ Win32VariantPointer >> write: anInnerVariant to: aVariant [
 	| type |
 
 	type := Win32Variant typeFor: 12.
-	aVariant vt: type typeNumber + 16r4000.
+	aVariant vt: type typeNumber + 16r4000. "VT_BYREF"
 	aVariant rawData pointerAt: 1 put: anInnerVariant getHandleAsExternalAddress  .
 ]

--- a/PharoCOM/Win32VariantUserDefined.class.st
+++ b/PharoCOM/Win32VariantUserDefined.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #Win32VariantUserDefinedType,
+	#name : #Win32VariantUserDefined,
 	#superclass : #Win32VariantType,
 	#category : #'PharoCOM-Variant-Types'
 }


### PR DESCRIPTION
Additions:
- `Win32VariantDate class` --> VT_DATE
- `Win32VariantDecimal class` --> VT_DECIMAL
- `Win32VariantDouble class` --> VT_DOUBLE
- `Win32VariantNull class` --> VT_NULL
- `COMDispatchInstance>>#propertyNamed:withArguments` --> Some property getters accept parameters
- `COMProperty>>#getFrom:withArguments:`
- `Win32VariantPointer>>#checkIfElementaryTypeAndWrite:to:` --> Supports calling the methods with arguments of type Variant *
- `#Win32VariantPointer>>write:to:` 

Extensions:
- `DateAndTime class>>#oleEpoch` -->  OLE epoch: days since midnight 30 December 1899
- `DateAndTime>>#asWin32VariantInto:` 
- `Date>>#asWin32VariantInto:`

Updates:
- `Win32Variant class>>#initializeTypemapping`

Tests:
- VariantsTests for Date, DateAndTime, Decimal, Double and Null
- Some tests updated

Various:
- `Win32VariantUserDefinedType` renamed to `Win32VariantUserDefinedType` for consistency
